### PR TITLE
Refactor build workflows to use justfile and shell scripts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,36 +34,17 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      - name: Install dependencies
+        run: uv sync --all-groups
+
       - name: Build package
-        run: uv build
+        run: uv run just build
 
       - name: Verify package contents
-        run: |
-          echo "Checking wheel contents..."
-          unzip -l dist/*.whl | grep -E '(py\.typed|README\.md|LICENSE)' || {
-            echo "ERROR: Missing required files in wheel"
-            exit 1
-          }
-          echo "Checking sdist contents..."
-          tar -tzf dist/*.tar.gz | grep -E '(py\.typed|README\.md|LICENSE|tests/)' || {
-            echo "ERROR: Missing required files in sdist"
-            exit 1
-          }
-          echo "✓ Package contents verified"
-
-      - name: List package contents
-        run: |
-          tar -tzf dist/*.tar.gz | head -20
-          unzip -l dist/*.whl | head -20
+        run: uv run just verify
 
       - name: Test installation from wheel
-        run: |
-          uv venv test-env
-          source test-env/bin/activate
-          uv pip install dist/*.whl
-          which immich-migrator
-          immich-migrator --help
-          immich-migrator version
+        run: uv run just test-install
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,22 +38,14 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      - name: Install dependencies
+        run: uv sync --all-groups
+
       - name: Build package
-        run: uv build
+        run: uv run just build
 
       - name: Verify package contents
-        run: |
-          echo "Checking wheel contents..."
-          unzip -l dist/*.whl | grep -E '(py\.typed|README\.md|LICENSE)' || {
-            echo "ERROR: Missing required files in wheel"
-            exit 1
-          }
-          echo "Checking sdist contents..."
-          tar -tzf dist/*.tar.gz | grep -E '(py\.typed|README\.md|LICENSE|tests/)' || {
-            echo "ERROR: Missing required files in sdist"
-            exit 1
-          }
-          echo "✓ Package contents verified"
+        run: uv run just verify
 
       - name: Publish to PyPI
         run: uv publish

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -19,12 +19,12 @@ jobs:
     # Grant minimal permissions required for release-please to create releases and PRs
     permissions:
       contents: write # Required to create releases and push commits
+      issues: write # Required to create release issues
       pull-requests: write # Required to create and update release PRs
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
-          release-type: python
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,55 @@
+# immich-migrator task runner
+#
+# This file delegates complex logic to shell scripts in ./scripts/
+# to ensure consistency between local development and CI/CD workflows.
+
+set shell := ["bash", "-c"]
+
+# List available commands
+default:
+    @just --list
+
+# Clean all build artifacts and caches
+clean:
+    ./scripts/clean
+
+# Run pre-commit hooks and tests
+check:
+    ./scripts/check
+
+# Build the package (sdist and wheel)
+build:
+    ./scripts/build
+
+# Verify the package contents
+verify:
+    ./scripts/verify-package
+
+# Test installation in a fresh environment
+test-install:
+    ./scripts/test-install
+
+# Install dependencies and set up the environment
+install:
+    uv sync --all-groups
+
+# Run linters (pre-commit hooks)
+lint:
+    uv tool run pre-commit run --all-files
+
+# Format code
+fmt:
+    uv run ruff format .
+    uv run ruff check --fix .
+
+# Run tests
+test:
+    uv run pytest
+
+# Run tests with coverage
+test-cov:
+    uv run pytest --cov=src/immich_migrator --cov-report=html --cov-report=term
+
+# Run the full release pipeline locally
+all: clean check build verify test-install
+    @echo "✅ All checks passed!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,4 +150,5 @@ dev = [
     "types-pyyaml>=6.0.0",
     "pre-commit>=4.5.0",
     "ruff>=0.14.8",
+    "rust-just>=1.45.0",
 ]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,176 @@
+# Scripts
+
+Build, test, and maintenance scripts for the project.
+
+## Quick Start with `just`
+
+This project uses `just` as a task runner. You can run tasks using `uv run just <task>`.
+
+```bash
+# List available tasks
+uv run just
+
+# Install dependencies (including dev and test groups)
+uv run just install
+
+# Run the full CI pipeline locally
+uv run just all
+
+# Build the package
+uv run just build
+
+# Run checks (lint + test)
+uv run just check
+
+# Run tests only
+uv run just test
+
+# Run tests with coverage
+uv run just test-cov
+
+# Format code
+uv run just fmt
+
+# Run linters only
+uv run just lint
+```
+
+## Build & Package Scripts
+
+### `./scripts/build` (or `just build`)
+
+Builds the Python package using `uv build`.
+
+**Usage:**
+
+```bash
+./scripts/build
+```
+
+**Output:** Creates distribution files in `dist/` directory:
+
+- `immich_migrator-{version}-py3-none-any.whl` (wheel)
+- `immich_migrator-{version}.tar.gz` (source distribution)
+
+### `./scripts/verify-package` (or `just verify`)
+
+Verifies that built packages contain all required files.
+
+**Usage:**
+
+```bash
+./scripts/verify-package
+```
+
+**Checks:**
+
+- ✅ Wheel contains: `py.typed`, `METADATA`, `LICENSE`
+- ✅ Sdist contains: `py.typed`, `README.md`, `LICENSE`, `tests/`
+
+**Note:** Run `./scripts/build` first.
+
+### `./scripts/test-install` (or `just test-install`)
+
+Tests installation of the built wheel in a clean virtual environment.
+
+**Usage:**
+
+```bash
+./scripts/test-install
+```
+
+**What it does:**
+
+1. Creates temporary virtual environment
+2. Installs the wheel
+3. Verifies CLI is accessible
+4. Runs `immich-migrator --help` and `immich-migrator version`
+5. Cleans up test environment
+
+**Note:** Run `./scripts/build` first.
+
+## Maintenance Scripts
+
+### `./scripts/clean` (or `just clean`)
+
+Removes all build artifacts and caches.
+
+**Usage:**
+
+```bash
+./scripts/clean
+```
+
+**Removes:**
+
+- `dist/`, `build/`, `*.egg-info/`
+- `__pycache__/`, `*.pyc`, `*.pyo`
+- `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`
+- Test artifacts and coverage reports
+
+### `./scripts/check` (or `just check`)
+
+Runs all pre-flight checks (linting, type-checking, tests).
+
+**Usage:**
+
+```bash
+./scripts/check
+```
+
+**What it does:**
+
+1. Runs `pre-commit` hooks on all files
+2. Runs `pytest` test suite
+
+## Complete Workflow
+
+**Development workflow:**
+
+```bash
+# Make changes to code...
+
+# Run checks before committing
+./scripts/check
+
+# Build and verify
+./scripts/build
+./scripts/verify-package
+./scripts/test-install
+```
+
+**Clean rebuild:**
+
+```bash
+./scripts/clean && ./scripts/build && ./scripts/verify-package
+```
+
+## CI/CD Usage
+
+These scripts are used by GitHub Actions workflows:
+
+- **`build.yaml`**: Calls `build`, `verify-package`, `test-install`
+- **`publish.yaml`**: Calls `build`, `verify-package`
+
+This ensures consistency between local development and CI builds.
+
+## Best Practices
+
+All scripts follow these conventions:
+
+- ✅ Use `set -euo pipefail` for safety
+- ✅ Calculate paths relative to project root
+- ✅ Include emoji indicators for readability
+- ✅ Provide clear error messages
+- ✅ Exit with non-zero code on failure
+- ✅ Can be run from any directory
+
+## Other Scripts
+
+### `check_immich_counts.py`
+
+Python script to verify Immich asset counts.
+
+### `regenerate_test_assets.sh`
+
+Regenerates test assets for the test suite.

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Build Python package using uv
+# Usage: ./scripts/build
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+
+echo "🔨 Building package with uv..."
+uv build
+
+echo ""
+echo "✅ Build complete!"
+ls -lh dist/

--- a/scripts/check
+++ b/scripts/check
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run all pre-flight checks (lint, type-check, tests)
+# Usage: ./scripts/check
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+
+echo "🔍 Running pre-commit hooks..."
+uv tool run pre-commit run --all-files
+
+echo ""
+echo "🧪 Running tests..."
+uv run pytest
+
+echo ""
+echo "✅ All checks passed!"

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Clean build artifacts and caches
+# Usage: ./scripts/clean
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+
+echo "🧹 Cleaning build artifacts..."
+
+# Remove build artifacts
+rm -rf dist/
+rm -rf build/
+rm -rf *.egg-info/
+rm -rf src/*.egg-info/
+
+# Remove Python caches
+find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+find . -type f -name "*.pyc" -delete 2>/dev/null || true
+find . -type f -name "*.pyo" -delete 2>/dev/null || true
+
+# Remove test artifacts
+rm -rf .pytest_cache/
+rm -rf .test-install-env/
+rm -rf htmlcov/
+rm -f .coverage
+rm -f coverage.xml
+
+# Remove type checking cache
+rm -rf .mypy_cache/
+
+# Remove linting cache
+rm -rf .ruff_cache/
+
+echo "✅ Clean complete!"

--- a/scripts/test-install
+++ b/scripts/test-install
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Test installation from built wheel
+# Usage: ./scripts/test-install
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+
+if [[ ! -d "dist" ]]; then
+    echo "❌ ERROR: dist/ directory not found. Run ./scripts/build first."
+    exit 1
+fi
+
+TEST_ENV="${PROJECT_ROOT}/.test-install-env"
+
+echo "🧪 Creating test virtual environment..."
+rm -rf "${TEST_ENV}"
+uv venv "${TEST_ENV}"
+
+echo "📥 Installing wheel in test environment..."
+# shellcheck disable=SC1091
+source "${TEST_ENV}/bin/activate"
+uv pip install dist/*.whl
+
+echo "🔍 Testing installed CLI..."
+which immich-migrator
+
+echo "📝 Running --help..."
+immich-migrator --help
+
+echo "🏷️  Running version command..."
+immich-migrator version
+
+echo ""
+echo "✅ Installation test passed"
+
+# Cleanup
+deactivate
+rm -rf "${TEST_ENV}"

--- a/scripts/verify-package
+++ b/scripts/verify-package
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Verify package contents and structure
+# Usage: ./scripts/verify-package
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+
+if [[ ! -d "dist" ]]; then
+    echo "❌ ERROR: dist/ directory not found. Run ./scripts/build first."
+    exit 1
+fi
+
+echo "🔍 Verifying wheel contents..."
+wheel_files=$(unzip -l dist/*.whl 2>/dev/null || true)
+if ! echo "$wheel_files" | grep -q 'py.typed'; then
+    echo "❌ ERROR: Missing py.typed in wheel"
+    exit 1
+fi
+if ! echo "$wheel_files" | grep -q 'METADATA'; then
+    echo "❌ ERROR: Missing METADATA in wheel"
+    exit 1
+fi
+if ! echo "$wheel_files" | grep -q 'LICENSE'; then
+    echo "❌ ERROR: Missing LICENSE in wheel"
+    exit 1
+fi
+
+echo "🔍 Verifying sdist contents..."
+sdist_files=$(tar -tzf dist/*.tar.gz 2>/dev/null || true)
+if ! echo "$sdist_files" | grep -q 'py.typed'; then
+    echo "❌ ERROR: Missing py.typed in sdist"
+    exit 1
+fi
+if ! echo "$sdist_files" | grep -q 'README.md'; then
+    echo "❌ ERROR: Missing README.md in sdist"
+    exit 1
+fi
+if ! echo "$sdist_files" | grep -q 'LICENSE'; then
+    echo "❌ ERROR: Missing LICENSE in sdist"
+    exit 1
+fi
+if ! echo "$sdist_files" | grep -q 'tests/'; then
+    echo "❌ ERROR: Missing tests/ directory in sdist"
+    exit 1
+fi
+
+echo "✅ Package contents verified"
+
+echo ""
+echo "📦 Package summary:"
+echo "  Wheel: $(ls -lh dist/*.whl | awk '{print $9, "(" $5 ")"}')"
+echo "  Sdist: $(ls -lh dist/*.tar.gz | awk '{print $9, "(" $5 ")"}')"

--- a/uv.lock
+++ b/uv.lock
@@ -322,6 +322,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "ruff" },
+    { name = "rust-just" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
 ]
@@ -352,6 +353,7 @@ dev = [
     { name = "mypy", specifier = ">=1.19.0" },
     { name = "pre-commit", specifier = ">=4.5.0" },
     { name = "ruff", specifier = ">=0.14.8" },
+    { name = "rust-just", specifier = ">=1.45.0" },
     { name = "types-pyyaml", specifier = ">=6.0.0" },
     { name = "types-requests", specifier = ">=2.32.0" },
 ]
@@ -907,6 +909,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/93/2a5063341fa17054e5c86582136e9895db773e3c2ffb770dde50a09f35f0/ruff-0.14.8-py3-none-win32.whl", hash = "sha256:15f04cb45c051159baebb0f0037f404f1dc2f15a927418f29730f411a79bc4e7", size = 13151890, upload-time = "2025-12-04T15:06:11.668Z" },
     { url = "https://files.pythonhosted.org/packages/02/1c/65c61a0859c0add13a3e1cbb6024b42de587456a43006ca2d4fd3d1618fe/ruff-0.14.8-py3-none-win_amd64.whl", hash = "sha256:9eeb0b24242b5bbff3011409a739929f497f3fb5fe3b5698aba5e77e8c833097", size = 14537826, upload-time = "2025-12-04T15:06:26.409Z" },
     { url = "https://files.pythonhosted.org/packages/6d/63/8b41cea3afd7f58eb64ac9251668ee0073789a3bc9ac6f816c8c6fef986d/ruff-0.14.8-py3-none-win_arm64.whl", hash = "sha256:965a582c93c63fe715fd3e3f8aa37c4b776777203d8e1d8aa3cc0c14424a4b99", size = 13634522, upload-time = "2025-12-04T15:06:43.212Z" },
+]
+
+[[package]]
+name = "rust-just"
+version = "1.45.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/83/8804ad2fbc12bbe05585fc13b525044c7f4c76b3f22368c9d7693e4b9e0d/rust_just-1.45.0.tar.gz", hash = "sha256:e17ed4a9d2e1d48ee024047371b71323c72194e4189cd7911184a3d4007cbe89", size = 1433575, upload-time = "2025-12-11T02:05:53.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/27/1357829369e9e037a66c3ab22ae35341d89cc05c66321377b1ab885cf661/rust_just-1.45.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f55a5ed6507189fb4c0c33821205f96739fab6c8c22c0264345749175bb6c59f", size = 1712097, upload-time = "2025-12-11T02:05:13.113Z" },
+    { url = "https://files.pythonhosted.org/packages/44/67/7cb63895b3869282291294ea73386f517f7471b4767e05680784d0eef08a/rust_just-1.45.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a63628432f2b7e214cfb422013ddd7bf436993d8e5406e5bf1426ea8a97c794b", size = 1595130, upload-time = "2025-12-11T02:05:15.719Z" },
+    { url = "https://files.pythonhosted.org/packages/69/69/f43363286b237b5ea1f43bb01792edd8bf5fbedb230f13b00a23bac34510/rust_just-1.45.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:037774833a914e6cf85771454dd623c9173dfa95f6c07033e528b4e484788f0d", size = 1677559, upload-time = "2025-12-11T02:05:18.197Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/af/34431539e1f072621a98e5891e436264f3028ca94267622c80ba8b11c2a3/rust_just-1.45.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:84d9d0e74e3e2f182002d9ed908c4dc9dac37bfa4515991df9c96f5824070aff", size = 1644684, upload-time = "2025-12-11T02:05:23.243Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/9d/b5a899977c3afa33997b1f1460f4aa198d8a4c496d98171c3468e25dd590/rust_just-1.45.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:76e4bbfbfcd7e0d49cd3952f195188504285d1e04418e1e74cc3180d92babd2b", size = 1821927, upload-time = "2025-12-11T02:05:26.733Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d1/0c5c29c591cf4cf4345ba26e789f35c9f434fb20a1701df9ce148f7f2a5f/rust_just-1.45.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f43123b9ecc122222ac3cae69f2e698cd44afb1b3fdb03e342b56f916295cbd8", size = 1898840, upload-time = "2025-12-11T02:05:29.238Z" },
+    { url = "https://files.pythonhosted.org/packages/51/5c/48e75a831926b9225a60ac602eb0dd8acd9002a6328ba02aaa91e0752e86/rust_just-1.45.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c9572941d9ee8a93e78973858561e5e01ce5f8e3eb466dbfe7dad226e73862ea", size = 1885445, upload-time = "2025-12-11T02:05:31.478Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d9/4c31345e96ca7072ce07123dda7c732421d7808e8be8382c87d72600b82a/rust_just-1.45.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5e7737429353aa43685671236994fb13eeac990056f487663d2fdfb77dd369d", size = 1806701, upload-time = "2025-12-11T02:05:34.032Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/25/ab55f3907fd479a1e28daaa178951d419799bae1dbab7ded3f09cae087b2/rust_just-1.45.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6fbe4634e3f4f7ba1d0b68d251da8e291377e1b75fecc1cf2dd8e89bfa577777", size = 1695387, upload-time = "2025-12-11T02:05:36.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/65/707ef48d339c2de4b6658e6c6d2c83f903fab5d9861b987833101cf2f6ac/rust_just-1.45.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:51d41861edd4872f430a3f8626ce5946581ab5f2f617767de9ff7f450b9d6498", size = 1667104, upload-time = "2025-12-11T02:05:39.3Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fe8466b95889203b93ff39b0ca92ca89af2330155bebee46165d481b0fa8/rust_just-1.45.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:00598b650295c97043175f27018c130a231cf15a62892231a42dfa8e7b4d70a2", size = 1811923, upload-time = "2025-12-11T02:05:42.279Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/1b/0c239cc3ff14ce6065ab6a1e879739e1e667cd6d482821679bc50bc77e3c/rust_just-1.45.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:22d5e4a963cd14c4e72c5733933a9478c4fe4b58684ac5c00a3da197b6cdbf70", size = 1871620, upload-time = "2025-12-11T02:05:45.603Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e3/3037f2db2cfddffd47f84c440dbf85fc83f96b3477c4c8b10364c1e4d261/rust_just-1.45.0-py3-none-win32.whl", hash = "sha256:33ba0085850fa0378ab479a4421ae79cf88e0e27589f401a63a26ce0c077ae6e", size = 1598481, upload-time = "2025-12-11T02:05:48.489Z" },
+    { url = "https://files.pythonhosted.org/packages/62/3f/1ef435ecc57191be4d34a85d09790a30b3659fac320093366c62af7c56e9/rust_just-1.45.0-py3-none-win_amd64.whl", hash = "sha256:3b660701191a2bf413483b9b9d00f1372574e656ab7d0ab3a19c7b2e4321a538", size = 1768810, upload-time = "2025-12-11T02:05:51.114Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR refactors the build and CI/CD workflows to use a **justfile** task runner with reusable shell scripts, improving maintainability and consistency between local development and CI environments.

## Changes

### New Files
- **justfile** - Task runner configuration with commands for build, test, verify, etc.
- **scripts/README.md** - Comprehensive documentation for all build scripts
- **scripts/build** - Build package script (creates sdist and wheel)
- **scripts/check** - Run pre-commit hooks and tests
- **scripts/clean** - Clean build artifacts and caches
- **scripts/verify-package** - Verify package contents (wheel and sdist)
- **scripts/test-install** - Test package installation in fresh environment

### Modified Files
- **.github/workflows/build.yaml** - Use `just` commands instead of inline scripts
- **.github/workflows/publish.yaml** - Use `just` commands for build and verify steps
- **.github/workflows/lint.yaml** - Add `develop` branch to trigger list
- **.github/workflows/release-please.yaml** - Add `issues: write` permission for release issues
- **pyproject.toml** - Add `rust-just>=1.45.0` to dev dependencies
- **uv.lock** - Lock file update for rust-just dependency

## Benefits

1. **DRY Principle** - Build logic is no longer duplicated across multiple workflow files
2. **Local Testing** - Developers can run the exact same commands locally that CI runs
3. **Maintainability** - Changes to build process only need to be made in one place
4. **Consistency** - Same scripts used across all workflows (build, publish, release)
5. **Debugging** - Easier to debug issues by running scripts locally

## Usage Examples

```bash
# List all available commands
uv run just

# Run full CI pipeline locally
uv run just all

# Build and verify package
uv run just build
uv run just verify

# Test installation
uv run just test-install
```

## Testing

All workflows have been updated to use the new script-based approach:
- Build workflow uses `just build`, `just verify`, and `just test-install`
- Publish workflow uses `just build` and `just verify`
- Local testing can replicate CI behavior exactly